### PR TITLE
Issue #71: Remove edit this page on GitHub links 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,6 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/open-dollar/od-docs/tree/main",
           sidebarCollapsed: false,
           sidebarCollapsible: false,
           remarkPlugins: [remarkMath],


### PR DESCRIPTION
Closes #71 

## Description
- growth team suggested removing the "edit this page on GitHub" link on each page to prevent spa,

## Screenshots

Before (edit this page visible)

<img width="1460" alt="befroe" src="https://github.com/open-dollar/od-docs/assets/47253537/6aa5806f-3956-47ae-8744-2977f9209296">

After

<img width="1449" alt="after" src="https://github.com/open-dollar/od-docs/assets/47253537/1007c654-2d66-4ebc-93c6-f48f12763527">

