### PR TITLE
Issue #99 Text formatting as LaTeX Issue

### DIFF
--- a/docs/How-OD-Stays-Stable.mdx
+++ b/docs/How-OD-Stays-Stable.mdx
@@ -2,7 +2,7 @@
 title: How OD Stays Stable
 ---
 
-If the price of OD deviates from its $1.00 peg, the PID Controller adjusts the redemption rate upwards or downwards in order to incentivize vault managers to restore it.
+If the price of OD deviates from its \$1.00 peg, the PID Controller adjusts the redemption rate upwards or downwards in order to incentivize vault managers to restore it.
 
 The following are two scenarios and how this works:
 

--- a/docs/PID-Failure-Modes--Responses.mdx
+++ b/docs/PID-Failure-Modes--Responses.mdx
@@ -44,7 +44,7 @@ In this scenario there are three possible solutions:
 
 In order to make market manipulation as expensive as possible, we propose the following liquidity thresholds for the OD stablecoin:
 
-* There must be at least $2M worth of liquidity on the exchange/s that the OD oracle is pulling a price feed from
-* At least 3% of the OD supply must be on the exchange/s from which the system is pulling a price feed from
+* There must be at least \$2M worth of liquidity on the exchange(s) that the OD oracle is pulling a price feed from
+* At least 3% of the OD supply must be on the exchange(s) from which the system is pulling a price feed from
 
 In addition to this, the PID controller should not be set to its full force right when OD is launched as it may destabilize the system.

--- a/docs/What-is-OD.mdx
+++ b/docs/What-is-OD.mdx
@@ -4,12 +4,12 @@ title: What is OD?
 
 ### Overview
 
-OD is Open Dollar’s robust and over-collateralized stablecoin backed by LSTs. It’s $1.00 floating peg is maintained by the protocol’s algorithm which adjusts it’s redemption rate by repricing debt, incentivizing vault managers to take actions to restore it’s value.
+OD is Open Dollar’s robust and over-collateralized stablecoin backed by LSTs. Its \$1.00 floating peg is maintained by the protocol’s algorithm which adjusts it’s redemption rate by repricing debt, incentivizing vault managers to take actions to restore its value.
 
 ### Features
 
-* Stable Value: Pegged to $1.00 for consistency and predictability in transactions.
+* Stable Value: Pegged to \$1.00 for consistency and predictability in transactions.
 * Over-Collateralization: Backed by an excess in collateral value, enhancing security.
-* Algorithmic Price Stability: OD's uses a dynamic control system called a PID controller, which continuously adjusts the redemption rate to maintain its $1.00 floating peg to the USD.
-* Arbitrage Opportunities: When OD's market price deviates from its $1.00 peg, the system's adjustments create arbitrage opportunities to restore it. This encourages users to buy or sell OD to realign its market price with the intended peg which benefits individual traders and the overall stability of the token.
+* Algorithmic Price Stability: OD's uses a dynamic control system called a PID controller, which continuously adjusts the redemption rate to maintain its \$1.00 floating peg to the USD.
+* Arbitrage Opportunities: When OD's market price deviates from its \$1.00 peg, the system's adjustments create arbitrage opportunities to restore it. This encourages users to buy or sell OD to realign its market price with the intended peg which benefits individual traders and the overall stability of the token.
 * Decentralized Nature: OD's decentralized framework diminishes reliance on centralized custodians, reducing risks associated with centralized control and enhancing the security and transparency of users' assets.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -7,7 +7,7 @@ description: Frequently asked questions about Open Dollar
 
 ### What is Open Dollar?
 
-Open Dollar is the protocol that issues OD, a floating $1.00 pegged stablecoin backed by Liquid Staking Tokens with NFT controlled vaults that is built for Arbitrum.
+Open Dollar is the protocol that issues OD, a floating \$1.00 pegged stablecoin backed by Liquid Staking Tokens with NFT controlled vaults that is built for Arbitrum.
 
 ### How does OD stay stable?
 
@@ -142,11 +142,11 @@ To better understand how OD behaves, we need to analyze its monetary policy whic
 
 Let's walk through an example of how OD is revalued in case of capital inflow of some Liquid Staked Token that we can call lstETH (meaning people are bullish on lstETH ):
 
-* At time T1: lstETH price is $500, OD's market and redemption prices are both $1.
-* At time T2: lstETH price surges to $1000. Open Dollar vault users suddenly have more borrowing power and generate more OD against their collateral. Those users sell OD on the secondary market (like an exchange), causing OD's market price to drop to $0.95. Users might be selling to create leveraged long positions, or to access capital without having to sell their lstETH.
-* At time T3: lstETH remains at $1000 and OD's market price is still $0.95. The protocol wants the market price to get close to the redemption price. In order to eliminate the imbalance between the market/redemption prices, the system starts to revalue OD. Revaluing consists in setting a positive redemption rate which makes the redemption price grow every second.
-* At time T4: lstETH remains at $1000. OD's redemption price is now $1.05. Vault users are starting to realize that they can now borrow less OD per one lstETH, they can redeem less lstETH during Settlement (because OD is now more expensive) and that it will be more expensive to close their vault once the market price follows the redemption price. At the same time, OD holders are starting to realize that they can redeem more and more ETH during settlement.
-* At time T5: lstETH remains at $1000. OD's redemption price is now $1.10. OD's market price surged to $1.01 as a result of vault users buying OD in order to close their positions as soon as possible instead of later on when OD is more expensive.
+* At time T1: lstETH price is \$500, OD's market and redemption prices are both \$1.
+* At time T2: lstETH price surges to \$1000. Open Dollar vault users suddenly have more borrowing power and generate more OD against their collateral. Those users sell OD on the secondary market (like an exchange), causing OD's market price to drop to \$0.95. Users might be selling to create leveraged long positions, or to access capital without having to sell their lstETH.
+* At time T3: lstETH remains at \$1000 and OD's market price is still \$0.95. The protocol wants the market price to get close to the redemption price. In order to eliminate the imbalance between the market/redemption prices, the system starts to revalue OD. Revaluing consists in setting a positive redemption rate which makes the redemption price grow every second.
+* At time T4: lstETH remains at \$1000. OD's redemption price is now \$1.05. Vault users are starting to realize that they can now borrow less OD per one lstETH, they can redeem less lstETH during Settlement (because OD is now more expensive) and that it will be more expensive to close their vault once the market price follows the redemption price. At the same time, OD holders are starting to realize that they can redeem more and more ETH during settlement.
+* At time T5: lstETH remains at \$1000. OD's redemption price is now \$1.10. OD's market price surged to \$1.01 as a result of vault users buying OD in order to close their positions as soon as possible instead of later on when OD is more expensive.
 
 When OD is devalued (in case of lstETH capital outflow), the opposite thing happens:
 

--- a/docs/risk/geb-risks.mdx
+++ b/docs/risk/geb-risks.mdx
@@ -4,7 +4,7 @@ title: GEB Risks
 
 # Protocol Risks
 
-Using Open Dollar and its associated assets doesn't come without risk. Before you decide to deposit your assets in the protocol or acquire the $OD stablecoin asset, you should do your research and understand the risks involved.
+Using Open Dollar and its associated assets doesn't come without risk. Before you decide to deposit your assets in the protocol or acquire the \$OD stablecoin asset, you should do your research and understand the risks involved.
 
 This section will only give an overview of the main risks associated with GEB. If you'd like to dive deeper, you can check out every [module](/system-contracts/core) in the System Contracts section.
 

--- a/docs/risk/pid-failure-modes-and-responses.mdx
+++ b/docs/risk/pid-failure-modes-and-responses.mdx
@@ -47,8 +47,8 @@ In this scenario there are three possible solutions:
 
 In order to make market manipulation as expensive as possible, we propose the following liquidity thresholds for the OD stablecoin:
 
-* There must be at least $2M worth of liquidity on the exchange/s that the OD oracle is pulling a price feed from
-* At least 3% of the OD supply must be on the exchange/s from which the system is pulling a price feed from
+* There must be at least \$2M worth of liquidity on the exchange(s) that the OD oracle is pulling a price feed from
+* At least 3% of the OD supply must be on the exchange(s) from which the system is pulling a price feed from
 
 In addition to this, the PID controller should not be set to its full force right when OD is launched as it may destabilize the system.
 


### PR DESCRIPTION
closes #99 

## Description
- Escapes dollar signs that were causing some text to be read as LaTeX
- Fixes typos

## Screenshots

<img width="1215" alt="fix formatting" src="https://github.com/open-dollar/od-docs/assets/47253537/759980a3-a433-4b7e-bd85-fb52f0645359">
